### PR TITLE
Add influxdb v2 output

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -6,7 +6,7 @@ They permit you to listen to UDP broadcasts from your Hub and:
  * print the received UDP broadcasts to stdout
  * print the decoded broadcasts in a more human-friendly form
  * publish derived topics to MQTT
- * publish derived topics to influxdb
+ * publish derived topics to influxdb (v1.x and v2.x)
  * support any combination of Air/Sky/Tempest
  * support multiple instances of Air/Sky/Tempest at your site
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These permit you to listen to UDP broadcasts from your Hub and:
  * print the received UDP broadcasts to stdout
  * print the decoded broadcasts in a more human-friendly form
  * publish derived topics to MQTT
- * publish derived topics to influxdb
+ * publish derived topics to influxdb (v1.x and v2.x)
  * support any combination of Air/Sky/Tempest
  * support multiple instances of Air/Sky/Tempest at your site
 
@@ -97,6 +97,16 @@ optional arguments:
                         InfluxDb password
   --influxdb_db INFLUXDB_DB
                         InfluxDb database name
+  --influxdb2           publish to InfluxDB v2
+  --influxdb2_url INFLUXDB2_URL
+                        InfluxDB v2 HTTP API root URL
+  --influxdb2_org INFLUXDB2_ORG
+                        InfluxDB v2 Organization
+  --influxdb2_bucket INFLUXDB2_BUCKET
+                        InfluxDB v2 Bucket
+  --influxdb2_token INFLUXDB2_TOKEN
+                        InfluxDB v2 Token
+  --influxdb2_debug     Debug InfluxDB v2 publisher
   -v, --verbose         verbose output to watch the threads
 
 for --limit, possibilities are:
@@ -321,7 +331,7 @@ It is also possible to publish directly to a influxdb database
 
 ### Example usage:
 
-This will print to a remote host 'influxdb' using a specified port and database, and also enable the multisensor syntax for more searchable generic topic names in the database.  This particular example requires no influxdb username/password, so those options have been omitted.
+This will print to InfluxDB v1.x on a remote host 'influxdb' using a specified port and database, and also enable the multisensor syntax for more searchable generic topic names in the database.  This particular example requires no influxdb username/password, so those options have been omitted.
 
 
 ```
@@ -330,6 +340,12 @@ This will print to a remote host 'influxdb' using a specified port and database,
 
 nohup wfudplistener --influxdb --influxdb_host=influxdb --influxdb_port=8086  --influxdb_db=testdb -M &
 
+```
+
+An equivalent example for InfluxDB v2.x:
+
+```
+nohup wfudplistener --influxdb --influxdb2_url="http://influxdb:8086"  --influxdb2_org=testorg --influxdb2_token=longsecret --influxdb2_bucket=weather -M &
 ```
 
 Initially it might make sense to add the -n (no_pub) flag to see is being published, to aid in you writing queries or grafana dashboards versus your influxdb data.  Remember, however, that the -n flag writes to stdout, so you'd want to run the command in the foreground.

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -655,7 +655,9 @@ def influxdb2_publish(event, data, args):
 def mqtt_publish(mqtt_host, mqtt_topic, data, args):
     import paho.mqtt.client  as mqtt
     import paho.mqtt.publish as publish
+    if args.verbose:
     print ("publishing to mqtt://%s/%s" % (mqtt_host, mqtt_topic))
+    
     if args.no_pub:
         print ("    ", json.dumps(data,sort_keys=True));
 

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -656,7 +656,7 @@ def mqtt_publish(mqtt_host, mqtt_topic, data, args):
     import paho.mqtt.client  as mqtt
     import paho.mqtt.publish as publish
     if args.verbose:
-    print ("publishing to mqtt://%s/%s" % (mqtt_host, mqtt_topic))
+        print ("publishing to mqtt://%s/%s" % (mqtt_host, mqtt_topic))
     
     if args.no_pub:
         print ("    ", json.dumps(data,sort_keys=True));

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -784,6 +784,13 @@ for --limit, possibilities are:
     parser.add_argument("--influxdb_user", dest="influxdb_user", action="store",                                      help="InfluxDB username")
     parser.add_argument("--influxdb_pass", dest="influxdb_pass", action="store",                                      help="InfluxDB password")
     parser.add_argument("--influxdb_db",   dest="influxdb_db",   action="store",      default="smartweather",         help="InfluxDB database name")
+    
+    parser.add_argument("--influxdb2",        dest="influxdb2",    action="store_true", help="publish to InfluxDB v2")
+    parser.add_argument("--influxdb2_url",    dest="influxdb2_url",    action="store", help="InfluxDB v2 HTTP API root URL", default="http://localhost:8086/")
+    parser.add_argument("--influxdb2_org",    dest="influxdb2_org", action="store", help="InfluxDB v2 Organization")
+    parser.add_argument("--influxdb2_bucket", dest="influxdb2_bucket", action="store", help="InfluxDB v2 Bucket")
+    parser.add_argument("--influxdb2_token", dest="influxdb2_token", action="store", help="InfluxDB v2 Token")
+    parser.add_argument("--influxdb2_debug", dest="influxdb2_debug", action="store_true", help="Debug InfluxDB v2 publisher")
 
     parser.add_argument("--mqtt_user", dest="mqtt_user", action="store", help="MQTT username (if needed)")
     parser.add_argument("--mqtt_pass", dest="mqtt_pass", action="store", help="MQTT password (if MQTT_USER has a password)")

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -805,10 +805,10 @@ for --limit, possibilities are:
         print ()
         sys.exit(1)
 
-    if (not args.mqtt) and (not args.decoded) and (not args.raw) and (not args.influxdb):
+    if (not args.mqtt) and (not args.decoded) and (not args.raw) and (not args.influxdb) and (not args.influxdb2):
         print ("\n#")
         print ("# exiting - must specify at least one option")
-        print ("#           --raw, --decoded, --mqtt, --influxdb")
+        print ("#           --raw, --decoded, --mqtt, --influxdb, --influxdb2")
         print ("#\n")
         parser.print_usage()
         print ()

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -741,7 +741,9 @@ def report_it(data):
 
 
 def main():
-
+    # we set these globals away from defaults only if they are passed as arguments
+    global ADDRESS, MQTT_HOST, MQTT_TOPLEVEL_TOPIC, MQTT_CLIENT_ID, MQTT_PORT
+    
     import argparse
 
     # argument parsing is u.g.l.y it ain't got no alibi, it's ugly !

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -617,6 +617,7 @@ def influxdb_publish(event, data):
 
 def influxdb2_publish(event, data):
     print("in influxdb2_publish")
+    print(f'args: {args}')
     # influxdb_client supports InfluxDB backends 1.8/2.0+ - v1.8 includes a v2 API layer.
     from influxdb_client import InfluxDBClient, Point, WritePrecision
     from influxdb_client.client.write_api import SYNCHRONOUS

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -622,7 +622,7 @@ def influxdb2_publish(event, data):
     from influxdb_client.client.write_api import SYNCHRONOUS
     print("done importing client")
 
-    if 'influxdb_client' not in sys.module:
+    if 'influxdb_client' not in sys.modules:
         print("you haven not imported influxdb_client succcessfully")
     else:
         print("looks like influxdb_client is available")

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -165,13 +165,13 @@ def process_evt_precip(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,evt_precip)
+        mqtt_publish(MQTT_HOST, topic, evt_precip, args)
 
     if args.influxdb:
-        influxdb_publish(topic, evt_precip)
+        influxdb_publish(topic, evt_precip, args)
         
     if args.influxdb2:
-        influxdb2_publish(topic, evt_precip)
+        influxdb2_publish(topic, evt_precip, args)
         
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -204,13 +204,13 @@ def process_evt_strike(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,evt_strike)
+        mqtt_publish(MQTT_HOST, topic, evt_strike, args)
 
     if args.influxdb:
-        influxdb_publish(topic, evt_strike)
+        influxdb_publish(topic, evt_strike, args)
         
     if args.influxdb2:
-        influxdb2_publish(topic, evt_strike)
+        influxdb2_publish(topic, evt_strike, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -243,13 +243,13 @@ def process_rapid_wind(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,rapid_wind)
+        mqtt_publish(MQTT_HOST, topic, rapid_wind, args)
 
     if args.influxdb:
-        influxdb_publish(topic, rapid_wind)
+        influxdb_publish(topic, rapid_wind, args)
             
     if args.influxdb2:
-        influxdb2_publish(topic, rapid_wind)
+        influxdb2_publish(topic, rapid_wind, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -291,13 +291,13 @@ def process_obs_air(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,obs_air)
+        mqtt_publish(MQTT_HOST, topic, obs_air, args)
 
     if args.influxdb:
-        influxdb_publish(topic, obs_air)
+        influxdb_publish(topic, obs_air, args)
         
     if args.influxdb2:
-        influxdb2_publish(topic, obs_air)
+        influxdb2_publish(topic, obs_air, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -362,13 +362,13 @@ def process_obs_st(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,obs_st)
+        mqtt_publish(MQTT_HOST, topic, obs_st, args)
 
     if args.influxdb:
-        influxdb_publish(topic, obs_st)
+        influxdb_publish(topic, obs_st, args)
         
     if args.influxdb2:
-        influxdb2_publish(topic, obs_st)
+        influxdb2_publish(topic, obs_st, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -421,13 +421,13 @@ def process_obs_sky(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,obs_sky)
+        mqtt_publish(MQTT_HOST, topic, obs_sky, args)
 
     if args.influxdb:
-        influxdb_publish(topic, obs_sky)
+        influxdb_publish(topic, obs_sky, args)
         
     if args.influxdb2:
-        influxdb2_publish(topic, obs_sky)
+        influxdb2_publish(topic, obs_sky, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -515,13 +515,13 @@ def process_device_status(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,device_status)
+        mqtt_publish(MQTT_HOST, topic, device_status, args)
 
     if args.influxdb:
-        influxdb_publish('device_status', device_status)
+        influxdb_publish('device_status', device_status, args)
         
     if args.influxdb2:
-        influxdb2_publish('device_status', device_status)
+        influxdb2_publish('device_status', device_status, args)
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -573,13 +573,13 @@ def process_hub_status(data,args):
         topic = "sensors/" + serial_number + "/" + topic
 
     if args.mqtt:
-        mqtt_publish(MQTT_HOST,topic,hub_status)
+        mqtt_publish(MQTT_HOST, topic, hub_status, args)
 
     if args.influxdb:
-        influxdb_publish(topic, hub_status)     # careful here, might need to hub_status.pop("foo", None) for arrays
+        influxdb_publish(topic, hub_status, args)     # careful here, might need to hub_status.pop("foo", None) for arrays
         
     if args.influxdb2:
-        influxdb2_publish(topic, hub_status)     # careful here, might need to hub_status.pop("foo", None) for arrays
+        influxdb2_publish(topic, hub_status, args)     # careful here, might need to hub_status.pop("foo", None) for arrays
     
     if args.verbose:
         print("finished publishing %s" % topic)
@@ -588,7 +588,7 @@ def process_hub_status(data,args):
 
 #----------------
 
-def influxdb_publish(event, data):
+def influxdb_publish(event, data, args):
     from influxdb import InfluxDBClient
 
     try:
@@ -615,9 +615,7 @@ def influxdb_publish(event, data):
 
 #----------------
 
-def influxdb2_publish(event, data):
-    print("in influxdb2_publish")
-    print(f'args: {args}')
+def influxdb2_publish(event, data, args):
     # influxdb_client supports InfluxDB backends 1.8/2.0+ - v1.8 includes a v2 API layer.
     from influxdb_client import InfluxDBClient, Point, WritePrecision
     from influxdb_client.client.write_api import SYNCHRONOUS

--- a/wfudptools/listener.py
+++ b/wfudptools/listener.py
@@ -652,7 +652,7 @@ def influxdb2_publish(event, data, args):
 
 #----------------
 
-def mqtt_publish(mqtt_host,mqtt_topic,data):
+def mqtt_publish(mqtt_host, mqtt_topic, data, args):
     import paho.mqtt.client  as mqtt
     import paho.mqtt.publish as publish
     print ("publishing to mqtt://%s/%s" % (mqtt_host, mqtt_topic))


### PR DESCRIPTION
Hi there!  I've been using `weatherflow-udp-listener` for the past few years with great results.  I added InfluxDB v2 support to my local copy, but never tried to upstream it.  I saw this new repo when migrating to a new machine and figured it would be a good time to do upstream this!

- Adds InfluxDB v2 support.  It uses a different auth model, so I did not attempt to reuse the existing arguments.  The client library it uses is officially supported by InfluxData.  The client also has support for pre-2.0 InfluxDB - I did not try to migrate existing InfluxDB 1.x output to the new library but would be happy to do so.
- Args are not globally available.  This caused a few problems with configuration that are now fixed by passing args into the publishers
    - Fixes issues with specifying custom MQTT broker addresses
    - Fixes issues with addresses/credentials for InfluxDB
- other minor "fixes"
    - fixed a date format in a comment
    - conditionalized some logging that seemed intended for verbose mode

Unresolved:
- I wound up using the MQTT broker address specified in the command line arguments everywhere rather than the existing `mqtt_host` / `MQTT_HOST` global.  Should the MQTT broker address be required?  Or should it default to `mqtt` when not specified?